### PR TITLE
fix(goreleaser): binary contains a wrong dot

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,5 +6,5 @@ archives:
     name_template: >-
       {{ .ProjectName }}_
       {{- .Os }}_
-      {{ .Arch }}
+      {{- .Arch }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}


### PR DESCRIPTION
For example `go-self-update_linux_.amd64` shpould be `go-self-update_linux_amd64`.